### PR TITLE
Add a "translated from" box underneath original text

### DIFF
--- a/css/polyglot.css
+++ b/css/polyglot.css
@@ -10,3 +10,23 @@
 span.polyglot-journal {
     background-color: rgba(255, 180, 0, 0.25)
 }
+
+.polyglot-translation-text{
+	position:relative;
+    padding: 20px 4px 0px 4px;
+    line-height: 24px;
+    background: rgba(0, 0, 0, 0.1);
+    border: 1px solid #999;
+    border-radius: 3px;
+    box-shadow: 0 0 2px #FFF inset;
+}
+
+.polyglot-translation-text:before{
+	position:absolute;
+	content: attr(title);
+	font-size:12px;
+	top:-2px;
+	left:4px;
+	font-weight: bold;
+    font-style: italic;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,8 @@
   "POLYGLOT.RandomizeRunesHint": "Enabling this option will cause the scrambled text to appear different every time, even if the same message is repeated.",
   "POLYGLOT.ExportFontsTitle": "Make fonts available",
   "POLYGLOT.ExportFontsHint": "Make the Polyglot fonts available for use in Foundry (in Drawings for example).",
+  "POLYGLOT.DisplayTranslatedTitle": "Display translated box",
+  "POLYGLOT.DisplayTranslatedHint": "For languages that are translated in the chat window, display the original text and a translation below.",
   "POLYGLOT.AllowOOCTitle": "Scramble on OOC chat messages",
   "POLYGLOT.AllowOOCHint": "Allows the GM to scramble text when sending Out Of Character messages",
   "POLYGLOT.LanguageLabel": "Language",


### PR DESCRIPTION
Code changes to leave untranslated text in the chat message and add a box underneath it with the translated text.