### PR TITLE
Filter Demon Lord languages to GM

### DIFF
--- a/polyglot.js
+++ b/polyglot.js
@@ -22,7 +22,8 @@ class PolyGlot {
 				}
 				return langs;
 			case "demonlord":
-				for (let language of Object.values(game.data.items)) {
+				const languages = game.data.items.filter(item => item.type === "language");
+				for (let language of languages) {
 					langs[language.name] = game.i18n.localize(language.name);
 				}
 				return langs;


### PR DESCRIPTION
This pull request to fix https://github.com/League-of-Foundry-Developers/fvtt-module-polyglot/pull/114.

`getLanguages` should filter by item type to return language items only. Currently shows all items as language.