### PR TITLE
Initial Support for Cyberpunk Red Core

### DIFF
--- a/module/LanguageProvider.js
+++ b/module/LanguageProvider.js
@@ -1762,3 +1762,151 @@ export class warhammerLanguageProvider extends LanguageProvider {
 		return [known_languages, literate_languages];
 	}
 }
+
+export class cyberpunkRedLanguageProvider extends LanguageProvider {
+	get originalAlphabets() {
+		return {
+			common: "130% Thorass",
+			cyrillic: "130% KremlinPremier",
+			miroslavnormal: "200% MiroslavNormal",
+			arciela: "200% ArCiela",
+			oriental: "130% Oriental",
+		};
+	}
+
+	get originalTongues() {
+		return {
+			_default: "common",
+			streetslang: "common",
+			arabic: "arciela",
+			bengali: "common",
+			berber: "common",
+			burmese: "arciela",
+			cantonese: "oriental",
+			chinese: "oriental",
+			cree: "common",
+			creole: "common",
+			dari: "common",
+			dutch: "common",
+			english: "common",
+			farsi: "arciela",
+			filipino: "arciela",
+			finnish: "cyrillic",
+			french: "common",
+			german: "miroslavnormal",
+			guarani: "common",
+			hausa: "common",
+			hawaiian: "common",
+			hebrew: "common",
+			hindi: "arciela",
+			indonesian: "arciela",
+			italian: "common",
+			japanese: "oriental",
+			khmer: "arciela",
+			korean: "oriental",
+			lingala: "common",
+			malayan: "arciela",
+			mandarin: "oriental",
+			maori: "common",
+			mayan: "common",
+			mongolian: "arciela",
+			navajo: "common",
+			nepali: "arciela",
+			norwegian: "miroslavnormal",
+			oromo: "common",
+			pamanyungan: "common",
+			polish: "cyrillic",
+			portuguese: "common",
+			quechua: "common",
+			romanian: "cyrillic",
+			russian: "cyrillic",
+			sinhalese: "common",
+			spanish: "common",
+			swahili: "common",
+			tahitian: "common",
+			tamil: "common",
+			turkish: "arciela",
+			twi: "common",
+			ukrainian: "cyrillic",
+			urdu: "arciela",
+			vietnamese: "arciela",
+			yoruba: "common",
+		};
+	}
+
+	async getLanguages() {
+		const replaceLanguages = game.settings.get("polyglot", "replaceLanguages");
+		const langs = {
+			streetslang: "Streetslang",
+			arabic: "Arabic",
+			bengali: "Bengali",
+			berber: "Berber",
+			burmese: "Burmese",
+			cantonese: "Cantonese",
+			chinese: "Chinese",
+			cree: "Cree",
+			creole: "Creole",
+			dari: "Dari",
+			dutch: "Dutch",
+			english: "English",
+			farsi: "Farsi",
+			filipino: "Filipino",
+			finnish: "Finnish",
+			french: "French",
+			german: "German",
+			guarani: "Guarani",
+			hausa: "Hausa",
+			hawaiian: "Hawaiian",
+			hebrew: "Hebrew",
+			hindi: "Hindi",
+			indonesian: "Indonesian",
+			italian: "Italian",
+			japanese: "Japanese",
+			khmer: "Khmer",
+			korean: "Korean",
+			lingala: "Lingala",
+			malayan: "Malayan",
+			mandarin: "Mandarin",
+			maori: "Maori",
+			mayan: "Mayan",
+			mongolian: "Mongolian",
+			navajo: "Navajo",
+			nepali: "Nepali",
+			norwegian: "Norwegian",
+			oromo: "Oromo",
+			pamanyungan: "Pama-nyungan",
+			polish: "Polish",
+			portuguese: "Portuguese",
+			quechua: "Quechua",
+			romanian: "Romanian",
+			russian: "Russian",
+			sinhalese: "Sinhalese",
+			spanish: "Spanish",
+			swahili: "Swahili",
+			tahitian: "Tahitian",
+			tamil: "Tamil",
+			turkish: "Turkish",
+			twi: "Twi",
+			ukrainian: "Ukrainian",
+			urdu: "Urdu",
+			vietnamese: "Vietnamese",
+			yoruba: "Yoruba",
+		};
+		this.languages = replaceLanguages ? {} : langs;
+	}
+
+	getUserLanguages(actor) {
+		let known_languages = new Set();
+		let literate_languages = new Set();
+		for (let item of actor.data.items) {
+			if (item.type == "skill") {
+				let myRegex = new RegExp("Language" + "\\s*\\((.+)\\)", "i");
+				const match = item.data.name.match(myRegex);
+				if (match) {
+					known_languages.add(match[1].trim().toLowerCase());
+				}
+			}
+		}
+		return [known_languages, literate_languages];
+	}
+}

--- a/module/api.js
+++ b/module/api.js
@@ -3,7 +3,7 @@ import {
 	LanguageProvider, ariaLanguageProvider, coc7LanguageProvider, d35eLanguageProvider, darkHeresyLanguageProvider, dccLanguageProvider,
 	demonlordLanguageProvider, dnd5eLanguageProvider, dsa5LanguageProvider, gurpsLanguageProvider, kryxrpgLanguageProvider, oseLanguageProvider,
 	pf1LanguageProvider, pf2eLanguageProvider, sfrpgLanguageProvider, shadowrun5eLanguageProvider, swadeLanguageProvider, sw5eLanguageProvider,
-	tormenta20LanguageProvider, uesrpgLanguageProvider, warhammerLanguageProvider,
+	tormenta20LanguageProvider, uesrpgLanguageProvider, warhammerLanguageProvider,cyberpunkRedLanguageProvider,
 } from "./LanguageProvider.js";
 
 export const availableLanguageProviders = {};
@@ -106,6 +106,9 @@ export function initApi() {
 			break;
 		case "wfrp4e":
 			languageProviders.push(new warhammerLanguageProvider("native.wfrp4e"));
+			break;
+		case "cyberpunk-red-core":
+			languageProviders.push(new cyberpunkRedLanguageProvider("native.cyberpunk-red-core"));
 			break;
 		default:
 			languageProviders.push(new LanguageProvider("native"));


### PR DESCRIPTION
This PR implements support for the Cyberpunk Red Core system (https://foundryvtt.com/packages/cyberpunk-red-core) and provides for players and game masters pre-defined languages as displayed in the core rule book (pg. 45). 

Regex filtering is used to match items where the type is "Skill" and the title of the skill is "Language ()". The values presented in parentheses are processed in `getLanguages` to provide an uppercase format. 

By default, everyone in the time of the red knows Streetslang. 

![image](https://user-images.githubusercontent.com/28914147/142754570-44e0f8aa-0bd9-4041-9e45-eca7d4e9a7d1.png)

Characters can then display their languages as expected by selecting the dropdown:
![polyglot-1](https://user-images.githubusercontent.com/28914147/142754617-7e51b5ba-0665-4faa-9b1d-c3168442412d.gif)

Polyglot fonts are included and set to provide a bit of visual difference between languages. 
![image](https://user-images.githubusercontent.com/28914147/142754695-13d9c454-f786-4193-9179-0977c0813e1f.png)

 
![polyglot-2](https://user-images.githubusercontent.com/28914147/142754810-3e0a489b-b347-4043-af14-78236a28ef08.gif)


